### PR TITLE
Fix execution condition of Exec['globus-node-setup']

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -164,7 +164,7 @@ class globus::config {
         path        => '/usr/bin:/bin:/usr/sbin:/sbin',
         command     => $node_setup,
         environment => ["GLOBUS_CLIENT_SECRET=${globus::client_secret}"],
-        creates     => '/var/lib/globus-connect-server/info.json',
+        unless      => 'test -s /var/lib/globus-connect-server/info.json',
         logoutput   => true,
         require     => Exec['globus-endpoint-setup'],
       }

--- a/spec/shared_examples/globus_config.rb
+++ b/spec/shared_examples/globus_config.rb
@@ -60,7 +60,7 @@ shared_examples_for 'globus::config' do |_facts|
       path: '/usr/bin:/bin:/usr/sbin:/sbin',
       command: node_setup.join(' '),
       environment: ['GLOBUS_CLIENT_SECRET=bar'],
-      creates: '/var/lib/globus-connect-server/info.json',
+      unless: 'test -s /var/lib/globus-connect-server/info.json',
       logoutput: 'true',
       require: 'Exec[globus-endpoint-setup]',
     )


### PR DESCRIPTION
Execution of the command `globus-node-setup` is currently expected to create the file `/var/lib/globus-connect-server/info.json`. However, since at least `globus-connect-server54` version `5.4.39`, the file is actually created by the preceding command `Exec['globus-endpoint-setup']`, but the file is left empty for `globus-node-setup` to fill.

This PR replaces the original condition 
```puppet
creates => '/var/lib/globus-connect-server/info.json'
```
by the following condition that tests that the file exists *and* is not empty.
```puppet
unless => 'test -s /var/lib/globus-connect-server/info.json'
```
This guarantees the execution of `globus-node-setup` regardless of which command creates the file `/var/lib/globus-connect-server/info.json` in preceding, current and future version of globus-connect-server.