### PR TITLE
Fix install for EL8 based OS

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,6 @@
 # @summary manage Globus install
 # @api private
 class globus::install {
-
   if String($globus::version) == '4' {
     if $globus::include_io_server {
       package { 'globus-connect-server-io':
@@ -23,9 +22,21 @@ class globus::install {
   }
 
   if String($globus::version) == '5' {
-    package { $globus::package_name:
-      ensure => 'present',
+    case $facts['os']['release']['major'] {
+      '8':  {
+        exec { 'dnf reset':
+          command => '/bin/dnf module -y disable mod_auth_openidc',
+          unless  => '/bin/rpm -aq | grep $globus::package_name',
+        }
+        package { $globus::package_name:
+          ensure => 'present',
+        }
+      }
+      default: {
+        package { $globus::package_name:
+          ensure => 'present',
+        }
+      }
     }
   }
-
 }


### PR DESCRIPTION
On EL8 (CentOS 8 Stream, AlmaLinux 8, RHEL8,...) the mod_auth_openidc stream needs to be disabled to prevent conflicts with packages in the Globus repository. For more info check
<https://docs.globus.org/globus-connect-server/v5/#gcsv5-install>.