### PR TITLE
Change lower and upper boundary for puppetlabs/firewall

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 1.0.0 <4.0.0"
+      "version_requirement": ">= 3.6.0 <6.0.0"
     },
     {
       "name": "puppet/epel",


### PR DESCRIPTION
Change module version of puppetlabs-firewall to use the latest version possible, that does not require puppetlabs-stdlib 9.x or higher.
Puppetlabs-stdlib 9.x or higher would introduce some breaking changes that need to be tested thoroughly first.