### PR TITLE
WIP: Bump firewall and epel upper module boundary

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,7 +10,6 @@ fixtures:
       repo: puppetlabs/inifile
     firewall:
       repo: puppetlabs/firewall
-      ref: '6.0.0'
     yumrepo_core:
       repo: puppetlabs/yumrepo_core
     python:

--- a/metadata.json
+++ b/metadata.json
@@ -22,11 +22,11 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 3.6.0 <7.0.0"
+      "version_requirement": ">= 3.6.0 <9.0.0"
     },
     {
       "name": "puppet/epel",
-      "version_requirement": ">= 3.0.0 <5.0.0"
+      "version_requirement": ">= 3.0.0 <6.0.0"
     },
     {
       "name": "puppet/python",

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 7.5.0 <10.0.0"
+      "version_requirement": ">= 7.5.0 <11.0.0"
     },
     {
       "name": "puppetlabs/inifile",
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 6.3.0 <8.0.0"
+      "version_requirement": ">= 6.3.0 <9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Preparation for Puppet 8 upgrade of this and other modules.

Also remove el7 from test matrix and nodeset, since CentOS 7.x is EOL since june 2024. Mirrorlist gives an error when trying to run the tests (does not exist anymore).