### PR TITLE
Fix quotes in endpoint_setup_args

### DIFF
--- a/lib/puppet/functions/globus/endpoint_setup_args.rb
+++ b/lib/puppet/functions/globus/endpoint_setup_args.rb
@@ -8,10 +8,10 @@ Puppet::Functions.create_function(:'globus::endpoint_setup_args') do
     flags = []
     flags << "'#{values['display_name']}'"
     flags << "--owner '#{values['owner']}'"
-    flags << "--project-id '#{values['project_id']}" unless values['project_id'].nil?
-    flags << "--project-admin '#{values['project_admin']}" unless values['project_admin'].nil?
+    flags << "--project-id '#{values['project_id']}'" unless values['project_id'].nil?
+    flags << "--project-admin '#{values['project_admin']}'" unless values['project_admin'].nil?
     flags << "--organization '#{values['organization']}'"
-    flags << "--deployment-key #{values['deployment_key']}"
+    flags << "--deployment-key '#{values['deployment_key']}'"
     flags << '--agree-to-letsencrypt-tos'
     flags << "--keywords '#{values['keywords'].join(',')}'" unless values['keywords'].nil?
     flags << "--department '#{values['department']}'" unless values['department'].nil?

--- a/spec/shared_examples/globus_config.rb
+++ b/spec/shared_examples/globus_config.rb
@@ -7,7 +7,7 @@ shared_examples_for 'globus::config' do |_facts|
       "'Example'",
       "--owner 'admin@example.com'",
       "--organization 'Example'",
-      '--deployment-key /var/lib/globus-connect-server/gcs-manager/deployment-key.json',
+      "--deployment-key '/var/lib/globus-connect-server/gcs-manager/deployment-key.json'",
       '--agree-to-letsencrypt-tos',
     ]
   end


### PR DESCRIPTION
I was getting an error of
```
Notice: /Stage[main]/Globus::Config/Exec[globus-endpoint-setup]/returns: sh: -c: line 1: unexpected EOF while looking for matching `''
Notice: /Stage[main]/Globus::Config/Exec[globus-endpoint-setup]/returns: sh: -c: line 2: syntax error: unexpected end of file
```
and my `/root/globus-endpoint-setup` was missing a closing quote for the project ID. Since most of the other values were single-quoted, even if not strictly required, I've added the missing closing quotes to project_id and project_admin, and quoted deployment_key.