### PR TITLE
Update puppetlabs-firewall requirements in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 3.6.0 <7.0.0"
+      "version_requirement": ">= 7.0.0 <8.0.0"
     },
     {
       "name": "puppet/epel",


### PR DESCRIPTION
Commit 1e103a8 introduced changes to firewall rules definition that are only compatible with puppetlabs-firewall >= v7.